### PR TITLE
remove broken dependency to govvv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 tmp/
 /*.yml
 .DS_Store
+
+bin/

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ else
 endif
 
 build:
-	@$(eval FLAGS := $$(shell PATH=$(PATH) govvv -flags -pkg github.com/anyproto/any-sync/app))
-	GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -ldflags "$(FLAGS)" -o bin/any-sync-network$(BIN_SUFFUX) ./any-sync-network
-	GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -ldflags "$(FLAGS)" -o bin/any-sync-netcheck$(BIN_SUFFUX) ./any-sync-netcheck
+	GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -o bin/any-sync-network$(BIN_SUFFUX) ./any-sync-network
+	GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -o bin/any-sync-netcheck$(BIN_SUFFUX) ./any-sync-netcheck
 
 deps:
 	go mod download


### PR DESCRIPTION
### Description

Running `make build` generates an error about govvv not found.

the govvv project is not maintained anymore and the command is not even used in the ci as you can see in the logs of the last gh action. You can see the following error message "line 1: govvv: command not found". The flags were empty so it is safe to just drop it.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
NA

### Mobile & Desktop Screenshots/Recordings

NA

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

