### PR TITLE
add a flag to generate a network configuration with defaults

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,61 @@
+on:
+  push: []
+
+name: build_and_test
+
+jobs:
+  build:
+    name: build release
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        os:
+          - linux
+          - windows
+          - darwin
+        go-version:
+          - 1.19.5
+        include:
+          - arch: amd64
+            rpm_arch: x86_64
+          - arch: arm64
+            rpm_arch: aarch64
+    env:
+      GOPRIVATE: github.com/anyproto
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '${{ matrix.go-version }}'
+      - name: git config
+        run: git config --global url.https://${{ secrets.ANYTYPE_PAT }}@github.com/.insteadOf https://github.com/
+      # cache {{
+      - id: go-cache-paths
+        run: |
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.GOCACHE }}
+            ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-${{ matrix.os }}-${{ matrix.arch }}-
+      # }}
+
+      # build {{
+      - name: deps
+        run: make deps
+
+      #- name: unit tests
+      #  run: make test
+      - name: test default config generation
+        run: go run any-sync-network/main.go create --defaults
+
+      - name: build
+        run: make build BUILD_GOOS=${{ matrix.os}} BUILD_GOARCH=${{ matrix.arch }}
+      # }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,9 @@ jobs:
         run: make build BUILD_GOOS=${{ matrix.os}} BUILD_GOARCH=${{ matrix.arch }}
       # }}
 
+      - name: test default config generation
+        run: ./bin/any-sync-network create --defaults
+
       - name: get release version
         id: release-version
         run: |

--- a/any-sync-network/cmd/root.go
+++ b/any-sync-network/cmd/root.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var defaultsFlag bool
+
 var rootCmd = &cobra.Command{
 	Use:   "anyconf",
 	Short: "Configuration builder for Any-Sync nodes.",
@@ -19,5 +21,6 @@ func Execute() {
 }
 
 func init() {
+	create.Flags().BoolVar(&defaultsFlag, "defaults", false, "generate configuration files using default parameters")
 	rootCmd.AddCommand(create)
 }


### PR DESCRIPTION
### Description

In order to generate a configuration for self-hosted setups we would need to use the any-sync-network CLI in a non interactive manner.

However the CLI is using the survey library for generating the configurations and this library does not support stdin as IO as described in
https://github.com/go-survey/survey#what-kinds-of-io-are-supported-by-survey.

This is a problem for automating the generation of a configuration for creating a docker based setup. We would rather avoid using static keys as in https://github.com/SamBouwer/any-docker because if by any bad luck the local setup is broken and starts to sync data on the public backup node instead of the local one, this could lead to serious troubles for the data, since the keys are public.

To avoid that situation, the cli should rather have a way to generate the configuration with default network values mainly for generating the security keys and leave it to the user to then further update the configurations as necessary. This only works for one node but in the case of self-hosted I think it is good enough for now.

Also, an alternative solution would have been to replace the survey library to use something able to read from stdin but this would be more intrusive and would have more potential for bugs after the change hence my proposal to introduce a simple --defaults flag to the command.


### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
NA

### Mobile & Desktop Screenshots/Recordings
NA

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed
