### PR TITLE
fix: consesus also need database uri

### DIFF
--- a/any-sync-network/cmd/create.go
+++ b/any-sync-network/cmd/create.go
@@ -245,6 +245,14 @@ var create = &cobra.Command{
 				},
 				Validate: survey.Required,
 			},
+			{
+				Name: "mongoConnect",
+				Prompt: &survey.Input{
+					Message: "Mongo connect URI",
+					Default: "mongodb://localhost:27017",
+				},
+				Validate: survey.Required,
+			},
 		}
 
 		consensusAs := struct {
@@ -252,6 +260,7 @@ var create = &cobra.Command{
 			YamuxPort    string
 			QuicPort     string
 			MongoDB      string
+			MongoConnect string
 		}{}
 
 		err = survey.Ask(consensusQs, &consensusAs)
@@ -264,6 +273,7 @@ var create = &cobra.Command{
 		consensusNode.Yamux.ListenAddrs = append(consensusNode.Yamux.ListenAddrs, consensusAs.Address + ":" + consensusAs.YamuxPort)
 		consensusNode.Quic.ListenAddrs = append(consensusNode.Quic.ListenAddrs, consensusAs.Address + ":" + consensusAs.QuicPort)
 		consensusNode.Mongo.Database = consensusAs.MongoDB
+		consensusNode.Mongo.Connect = consensusAs.MongoConnect
 		consensusNode.Account = generateAccount()
 
 		addToNetwork(consensusNode.GeneralNodeConfig, "consensus")


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

consensus also need database uri, if not it will output a blank string
![image](https://github.com/anyproto/any-sync-tools/assets/82284393/9acb0e3f-a285-4a22-9dcf-6fea985a3722)


<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
