### PR TITLE
added non-interactive generation mode with the --auto flag

### DIFF
--- a/any-sync-network/README.md
+++ b/any-sync-network/README.md
@@ -2,9 +2,9 @@
 Configuration builder for Any-Sync nodes.
 
 ## Installation
-You can download the binary release here: https://github.com/anyproto/any-sync-tools/releases  
+You can download the binary release here: https://github.com/anyproto/any-sync-tools/releases
 
-#### Build from source   
+#### Build from source
 ```
 go install github.com/anyproto/any-sync-tools/any-sync-network@latest
 ```
@@ -13,11 +13,16 @@ go install github.com/anyproto/any-sync-tools/any-sync-network@latest
 ```
 any-sync-network create
 ```
-Use the interactive CLI to describe the parameters of basic nodes and create additional nodes if needed. 
+Use the interactive CLI to describe the parameters of basic nodes and create additional nodes if needed.
+
+```
+any-sync-network create --auto
+```
+Use  this for completely non-interactive generation. Do not forget to specify the values of the variables you need in `defaultTemplate.yml` file.
 
 Note that there are prerequisites for successful configuration:
-1. `any-sync-coordinator` node and `any-sync-consensusnode` require MongoDB.
-2. `any-sync-filenode` requires an S3-compatible object storage and Redis.
+1. `any-sync-coordinator` node and `any-sync-consensusnode` require MongoDB in replica-set mode.
+2. `any-sync-filenode` requires an S3-compatible object storage (Minio/AWS S3) and Redis with Bloom module.
 
 You can use the generated `*.yml` files as your nodes' and `anytype-heart`'s configurations.
 

--- a/any-sync-network/cmd/root.go
+++ b/any-sync-network/cmd/root.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var autoFlag bool
+var templatePath string
 var rootCmd = &cobra.Command{
 	Use:   "anyconf",
 	Short: "Configuration builder for Any-Sync nodes.",
@@ -20,4 +22,6 @@ func Execute() {
 
 func init() {
 	rootCmd.AddCommand(create)
+	create.Flags().BoolVar(&autoFlag, "auto", false, "auto generation in non-interactive mode")
+	create.Flags().StringVar(&templatePath, "c", "./defaultTemplate.yml", "path to the template file")
 }

--- a/any-sync-network/defaultTemplate.yml
+++ b/any-sync-network/defaultTemplate.yml
@@ -1,0 +1,45 @@
+external-addresses:
+ - 127.0.0.1
+
+any-sync-coordinator:
+  listen: any-sync-coordinator
+  yamuxPort: 4830
+  quicPort: 5830
+  mongo:
+    connect: mongodb://localhost:27017
+    database: coordinator
+  defaultLimits:
+    spaceMembersRead: 1000
+    spaceMembersWrite: 1000
+    sharedSpacesLimit: 1000
+
+any-sync-consensusnode:
+  listen: any-sync-consensusnode
+  yamuxPort: 4530
+  quicPort: 5530
+  mongo:
+    connect: mongodb://localhost:27017/?w=majority
+    database: consensus
+
+any-sync-filenode:
+  listen: any-sync-filenode
+  yamuxPort: 4730
+  quicPort: 5730
+  s3Store:
+    endpoint: http://localhost:9000
+    bucket: minio-bucket
+    indexBucket: minio-bucket
+    region: us-east-1
+    profile: default
+    forcePathStyle: true
+  redis:
+    url: redis://localhost:6379?dial_timeout=3&read_timeout=6s
+  defaultLimit: 1099511627776
+
+any-sync-node:
+  listen:
+  - any-sync-node-1
+  - any-sync-node-2
+  - any-sync-node-3
+  yamuxPort: 4430
+  quicPort: 5430


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
